### PR TITLE
:sparkles: feat: Support multi-types parameters

### DIFF
--- a/lib/boring-service.rb
+++ b/lib/boring-service.rb
@@ -57,8 +57,8 @@ class BoringService
     # Parameters are also inherited from superclasses and can be redefined (overwritten) in subclasses.
     #
     # @param name [Symbol] name of the parameter
-    # @param type [Class, #===] type of the parameter. Can be a Class, a Proc or anything that defines a meaningful
-    #   `===` method
+    # @param type [Class, Array, #===] type of the parameter. Can be a Class, an Array of classes, a Proc, or anything
+    # that defines a meaningful `===` method.
     # @param **options [Hash] extra options for the parameter
     # @option **options [Object, #call] :default default value if the parameter is not passed. If the default implements
     #   `#call`, it gets called once in the context of the method object instance when it is instantiated.

--- a/lib/boring-service/parameter.rb
+++ b/lib/boring-service/parameter.rb
@@ -32,8 +32,13 @@ class BoringService
       end
     end
 
+    # rubocop:disable Style/CaseEquality
     def acceptable?(value)
-      (value.nil? && nullable?) || type === value # rubocop:disable Style/CaseEquality
+      if type.is_a?(Array)
+        type.any? { |t| t === value } 
+      else 
+        (value.nil? && nullable?) || type === value 
+      end
     end
 
     def nullable?

--- a/lib/boring-service/version.rb
+++ b/lib/boring-service/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class BoringService
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/boring_service_spec.rb
+++ b/spec/boring_service_spec.rb
@@ -21,6 +21,14 @@ class CustomService < BoringService
   end
 end
 
+class MultiTypeService < BoringService
+  parameter :required_param, [String, Integer]
+
+  def call
+    puts required_param
+  end
+end
+
 RSpec.describe BoringService do
   describe ".call" do
     it "should raise an error if a required param is not passed" do
@@ -45,6 +53,18 @@ RSpec.describe BoringService do
       class BadService < BoringService; end
 
       expect { BadService.call }.to raise_error NotImplementedError
+    end
+
+    it "should support multiple types for a parameter" do
+      response = MultiTypeService.call(required_param: "foo")
+      expect(response[:required_param]).to eq "foo"
+
+      response = MultiTypeService.call(required_param: 5)
+      expect(response[:required_param]).to eq 5
+    end
+
+    it "should raise an error if the param type is not includes in the expected types array" do
+      expect { MultiTypeService.call(required_param: 5.5) }.to raise_error BoringService::InvalidParameterValue
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'boring-service'
 
 Dir[File.expand_path("../support/*.rb", __FILE__)].sort.each { |f| require f }


### PR DESCRIPTION
Now parameters can be defined with an array of types. At runtime, if the passed argument has a type present in the array of type, it will be considered a valid parameter.

This allows cases such as:

```ruby
class CalculatorService < BoringService
  parameter :num_1, [Float, Integer]
  parameter :num_2, [Float, Integer]


  def call
    puts "Sum of #{num_1} and #{num_2} is equal to #{num1 + num_2}"     
  end
end
```


Closes #2